### PR TITLE
Asset storage file-backed + cache LRU + CloudKit threshold

### DIFF
--- a/Docs/AssetsFileBacked.md
+++ b/Docs/AssetsFileBacked.md
@@ -1,57 +1,215 @@
-# GraphNext — Asset Storage (File‑backed)
+# Assets (File‑Backed)
 
-**Obiettivo**  
-Tutti gli asset sono file‑backed su disco locale. Nel database (GRDB/Core Data) restano **solo i metadati** (sha256, length, mimeType, fileName) nel `payload` della `Entity` con `type: "asset"`, e i link logici sono espressi via `Relationship` (es. `attaches`).
+**Stato:** attivo  
+**Target:** iOS 16+  
+**Moduli:** GraphNext (Store, Persistence GRDB/Core Data), GraphSyncEngine (CloudKit)
 
-**Architettura**  
-- `AssetStorage` (protocol) definisce l’interfaccia.
-- `FileAssetStorage` è l’implementazione di default:
-  - Contenuti content‑addressed in `content/<aa>/<bb>/<sha256>`.
-  - Indice locale `index/<assetId>.json` → risolve `assetId` → `sha256` e metadati, aggiorna `lastAccess`.
-  - Dedup automatico per `sha256`.
-  - Pronto per futura **LRU eviction** (usa `lastAccess`).
+## Perché file‑backed
+- **Niente BLOB in DB**: schema più pulito, meno I/O sul database.
+- **Coerenza con CloudKit**: usa `CKAsset(fileURL:)`.
+- **API pubbliche stabili**: nessuna rottura per i consumatori.
+- **Pull‑from‑zero veloce**: gli asset si scaricano **on‑demand**.
 
-**Motivazioni**
-- Niente BLOB nel DB → schema più pulito, persistenza più rapida, i backup del DB restano leggeri.
-- Allineamento immediato a **CloudKit/CKAsset** (usa URL locali) e a Core Data (no binari in Core Data).
-- Pull‑from‑zero più veloce: gli asset si scaricano **on‑demand**.
+---
 
-**Roadmap integrazione (PR successive)**
-1. GRDB: rimuovere tabella `asset_blobs` e route binari → solo metadati nel `payload`.
-2. Core Data: stesso approccio (niente BLOB).
-3. CloudKit: `CKAsset` creati da URL locale (push), download on‑demand (pull) → `fetchAssetIfNeeded`.
-4. API pubbliche stabili (`createAssetAndAttach`, `loadAssetData`, `openAssetStream`, `assetURLIfPresent`, `delete`, `fetchAssetIfNeeded`).
-5. Cache/eviction: configurazione quota (es. 200 MB) e LRU.
+## Concetti chiave
 
-**Note**
-- La deduplica elimina duplicati per contenuti identici: più `assetId` possono puntare allo stesso file (stesso `sha256`). La rimozione cancella il contenuto solo quando nessun altro indice lo referenzia.
+- Un asset è una `Entity` con `type == "asset"` che contiene **solo metadati** nel `payload`:
+  - `mimeType: String`
+  - `fileName: String`
+  - `length: Int`
+  - `sha256: String` (hex)
+- I byte reali sono salvati su disco da `AssetStorage` (default: `FileAssetStorage`).
+- La relazione con il “proprietario” è `Relationship(type:"attaches")`: `owner --attaches--> asset`.
 
-## PR #2 — GRDB refactor (file-backed)
+---
 
-- Rimosso ogni utilizzo della tabella `asset_blobs` nel codice.
-- Tutte le operazioni su asset binari usano `AssetStorage` (default `FileAssetStorage`).
-- Esposte API pubbliche sul controller GRDB:
-  - `saveAssetData(assetId:data:mimeType:fileName:)`
-  - `loadAssetData(assetId:)`
-  - `openAssetStream(assetId:)`
-  - `assetURLIfPresent(assetId:)`
-  - `deleteAsset(assetId:)`
-  - `fetchAssetIfNeeded(assetId:)` (no-op per GRDB)
-- `createAssetAndAttach(...)` ora salva i dati su file storage e scrive solo metadati nel `payload` dell’`Entity(type:"asset")`.
+## API pubbliche (superficie invariata)
 
-> Nella PR #3 verrà **droppata** la tabella `asset_blobs` tramite migrazione GRDB.
+```swift
+// Crea asset + relation "attaches" al proprietario; salva i byte via storage
+func createAssetAndAttach(
+    data: Data,
+    mimeType: String?,
+    fileName: String?,
+    attachTo ownerId: UUID
+) async throws -> Entity
 
-## PR #4 — Core Data integrazione (file‑backed)
+// Salva/aggiorna solo i bytes di un asset esistente; ritorna metadati
+@discardableResult
+func saveAssetData(
+    assetId: UUID,
+    data: Data,
+    mimeType: String,
+    fileName: String?
+) async throws -> AssetMetadata
 
-- Nessun `Binary Data`/BLOB in Core Data: gli asset sono `Entity(type:"asset")` con metadati nel `payload`.
-- Binari salvati su disco tramite `AssetStorage` (default: `FileAssetStorage`).
-- API pubbliche allineate a GRDB:
-  - `saveAssetData(assetId:data:mimeType:fileName:)`
-  - `loadAssetData(assetId:)`
-  - `openAssetStream(assetId:)`
-  - `assetURLIfPresent(assetId:)`
-  - `deleteAsset(assetId:)`
-  - `fetchAssetIfNeeded(assetId:)` (no‑op per Core Data)
-  - `createAssetAndAttach(data:mimeType:fileName:attachTo:)`
-- `deleteEntity(id:)` rimuove anche il file locale quando l’entity è un asset (best‑effort).
-- Test in‑memory `CoreDataFileBackedAssetsTests` verdi.
+// Carica tutti i bytes (streaming interno)
+func loadAssetData(assetId: UUID) async throws -> Data
+
+// Stream di sola lettura
+func openAssetStream(assetId: UUID) async throws -> InputStream?
+
+// URL locale se presente (non forza download)
+func assetURLIfPresent(assetId: UUID) async throws -> URL?
+
+// Rimuove solo il file locale (non l’entity)
+func deleteAsset(assetId: UUID) async throws
+
+// CloudKit: scarica file on‑demand se necessario
+func fetchAssetIfNeeded(assetId: UUID) async throws
+```
+
+> Nota: in CloudKit abbiamo anche la **convenience** sul sync:  
+> `CloudKitSync.fetchAssetIfNeededAndNotify(assetId:)` che, dopo il download, invia un `.update` sullo `Store` (Combine) tramite `store.notifyAssetReady(_:)`.
+
+---
+
+## AssetStorage
+
+```swift
+protocol AssetStorage {
+    @discardableResult
+    func save(data: Data, for assetId: UUID, meta: AssetMetadata) throws -> URL
+    func openRead(assetId: UUID) throws -> InputStream?
+    func urlIfPresent(assetId: UUID) throws -> URL?
+    func exists(assetId: UUID) throws -> Bool
+    func remove(assetId: UUID) throws
+    func verifyChecksum(assetId: UUID) throws -> Bool
+}
+
+struct AssetMetadata: Equatable {
+    let length: Int
+    let sha256: String
+    let mimeType: String?
+    let fileName: String?
+}
+```
+
+**Default:** `FileAssetStorage`
+- Directory dedicata (es. `.../GN_Assets_<UUID>/content/`).
+- Sharding su SHA256 (per evitare troppe entry per cartella).
+- `verifyChecksum` via SHA256 del file.
+
+---
+
+## Integrazioni
+
+### GRDB
+- **Nessun BLOB** in tabelle — solo metadati in `Entity.payload`.
+- I metodi `deleteEntity(id:)` rimuovono **best‑effort** anche il file locale quando `type == "asset"`.
+
+### Core Data
+- Nessun campo `Binary Data`; stessi metadati nel `payload`.
+- Stessa logica **best‑effort** in `delete...` per rimuovere i file locali.
+
+### CloudKit
+- **Push**: `Entity.asCKRecord()` allega `record["file"] = CKAsset(fileURL:)` se il file locale esiste; metadati **sempre** nel `payload`.
+- **Pull**: solo metadati; **niente** copia automatica dei byte.
+- **On‑demand**:  
+  - `CloudKitSync.fetchAssetIfNeeded(assetId:)` effettua `CKFetchRecordsOperation` con `desiredKeys: ["file"]` e salva il file nello storage.
+  - `CloudKitSync.fetchAssetIfNeededAndNotify(assetId:)` → in più chiama `store.notifyAssetReady(_:)` (Combine `.update`).
+
+**Config CloudKit:**
+```swift
+struct CloudKitSyncConfig {
+    var containerIdentifier: String?
+    var zoneName: String
+    var stateStore: StateStore
+    var subscribeOnInit: Bool
+    var pushBatchSize: Int      // default: 100
+    var pushMaxIntervalSeconds: Double // default: 3.0
+    var debounceMilliseconds: Int
+    var retryMaxAttempts: Int
+    var retryBaseDelaySeconds: Double
+    var assetThresholdBytes: Int // default: 15 MB (reserved for policy, wiring next)
+}
+```
+
+---
+
+## Esempi d’uso
+
+### Creare e collegare un asset a un documento
+```swift
+let owner = try await storeController.createDocument(...) // o saveEntity(...)
+let data: Data = ... // bytes
+let asset = try await controller.createAssetAndAttach(
+    data: data,
+    mimeType: "application/pdf",
+    fileName: "report.pdf",
+    attachTo: owner.id
+)
+```
+
+### Caricare l’asset (se già locale)
+```swift
+if let url = try await controller.assetURLIfPresent(assetId: asset.id) {
+    // uso diretto dell’URL (read-only)
+} else {
+    // CloudKit: scarico on-demand e notifico la UI
+    try await cloudKitSync.fetchAssetIfNeededAndNotify(assetId: asset.id)
+}
+```
+
+### Ascoltare aggiornamenti (Combine)
+```swift
+store.changeFeed
+    .sink { change in
+        if case let .update(node, isRemote) = change,
+           let e = node as? Entity, e.type == "asset", isRemote {
+            // asset diventato disponibile offline: aggiornare UI
+        }
+    }
+    .store(in: &cancellables)
+```
+
+---
+
+## Migrazione (PR3)
+- Rimosse strutture legacy: `asset_blobs` + indici (`DROP ... IF EXISTS`).
+- Nessuna migrazione dati (libreria non rilasciata).
+
+---
+
+## Test (principali)
+
+- **Round-trip** (GRDB/Core Data): create → save → load → checksum → delete → file sparito.
+- **CloudKit Mapper**: `asCKRecord` allega `CKAsset` se URL locale presente.
+- **CloudKit On‑Demand**: fetch con test‑hook → file in storage → `notifyAssetReady`.
+- **Schema GRDB**: niente `asset_blobs` in `sqlite_master`.
+
+---
+
+## Best‑practice & guardrail
+
+- **NON** creare manualmente `Entity(type:"asset")`. Usare **sempre** `createAssetAndAttach(...)`.
+- Usare `assetURLIfPresent` per evitare I/O non necessario; se `nil`, usare **on‑demand**.
+- Non salvare segreti nel `payload` degli asset (solo metadati tecnici).
+- Considerare `mimeType`/`fileName` opzionali (fallback `application/octet-stream`).
+
+---
+
+## Roadmap (next)
+
+- **Eviction/Cache (PR6b)**: quota (es. 200 MB) con LRU (aggiorna `lastAccess` su `openRead`).
+- **Soglia “light/heavy”**: usare `assetThresholdBytes` in push per non allegare file troppo grandi.
+- **Miglioramenti diagnostica**: logging coerente su asset mancanti.
+
+---
+
+### Changelog
+- **PR1–2**: AssetStorage + GRDB file‑backed, API pubbliche.
+- **PR3**: drop `asset_blobs`.
+- **PR4**: Core Data integrazione (file‑backed).
+- **PR5**: CloudKit: CKAsset + on‑demand + notify Store.
+- **PR6a**: Documentazione aggiornata (questo file).
+
+---
+
+### Link correlati
+- `Sources/GraphNext/Persistence/Assets/*`
+- `Sources/GraphNext/Persistence/GRDB/*`
+- `Sources/GraphNext/Persistence/CoreData/*`
+- `Sources/GraphSyncEngine/CloudKit/*`
+- Test: `Tests/GraphNextTests/Assets/*`, `Tests/GraphNextTests/CloudKit/*`

--- a/Docs/AssetsFileBacked.md
+++ b/Docs/AssetsFileBacked.md
@@ -40,3 +40,18 @@ Tutti gli asset sono file‑backed su disco locale. Nel database (GRDB/Core Data
 - `createAssetAndAttach(...)` ora salva i dati su file storage e scrive solo metadati nel `payload` dell’`Entity(type:"asset")`.
 
 > Nella PR #3 verrà **droppata** la tabella `asset_blobs` tramite migrazione GRDB.
+
+## PR #4 — Core Data integrazione (file‑backed)
+
+- Nessun `Binary Data`/BLOB in Core Data: gli asset sono `Entity(type:"asset")` con metadati nel `payload`.
+- Binari salvati su disco tramite `AssetStorage` (default: `FileAssetStorage`).
+- API pubbliche allineate a GRDB:
+  - `saveAssetData(assetId:data:mimeType:fileName:)`
+  - `loadAssetData(assetId:)`
+  - `openAssetStream(assetId:)`
+  - `assetURLIfPresent(assetId:)`
+  - `deleteAsset(assetId:)`
+  - `fetchAssetIfNeeded(assetId:)` (no‑op per Core Data)
+  - `createAssetAndAttach(data:mimeType:fileName:attachTo:)`
+- `deleteEntity(id:)` rimuove anche il file locale quando l’entity è un asset (best‑effort).
+- Test in‑memory `CoreDataFileBackedAssetsTests` verdi.

--- a/Docs/AssetsFileBacked.md
+++ b/Docs/AssetsFileBacked.md
@@ -1,0 +1,42 @@
+# GraphNext — Asset Storage (File‑backed)
+
+**Obiettivo**  
+Tutti gli asset sono file‑backed su disco locale. Nel database (GRDB/Core Data) restano **solo i metadati** (sha256, length, mimeType, fileName) nel `payload` della `Entity` con `type: "asset"`, e i link logici sono espressi via `Relationship` (es. `attaches`).
+
+**Architettura**  
+- `AssetStorage` (protocol) definisce l’interfaccia.
+- `FileAssetStorage` è l’implementazione di default:
+  - Contenuti content‑addressed in `content/<aa>/<bb>/<sha256>`.
+  - Indice locale `index/<assetId>.json` → risolve `assetId` → `sha256` e metadati, aggiorna `lastAccess`.
+  - Dedup automatico per `sha256`.
+  - Pronto per futura **LRU eviction** (usa `lastAccess`).
+
+**Motivazioni**
+- Niente BLOB nel DB → schema più pulito, persistenza più rapida, i backup del DB restano leggeri.
+- Allineamento immediato a **CloudKit/CKAsset** (usa URL locali) e a Core Data (no binari in Core Data).
+- Pull‑from‑zero più veloce: gli asset si scaricano **on‑demand**.
+
+**Roadmap integrazione (PR successive)**
+1. GRDB: rimuovere tabella `asset_blobs` e route binari → solo metadati nel `payload`.
+2. Core Data: stesso approccio (niente BLOB).
+3. CloudKit: `CKAsset` creati da URL locale (push), download on‑demand (pull) → `fetchAssetIfNeeded`.
+4. API pubbliche stabili (`createAssetAndAttach`, `loadAssetData`, `openAssetStream`, `assetURLIfPresent`, `delete`, `fetchAssetIfNeeded`).
+5. Cache/eviction: configurazione quota (es. 200 MB) e LRU.
+
+**Note**
+- La deduplica elimina duplicati per contenuti identici: più `assetId` possono puntare allo stesso file (stesso `sha256`). La rimozione cancella il contenuto solo quando nessun altro indice lo referenzia.
+
+## PR #2 — GRDB refactor (file-backed)
+
+- Rimosso ogni utilizzo della tabella `asset_blobs` nel codice.
+- Tutte le operazioni su asset binari usano `AssetStorage` (default `FileAssetStorage`).
+- Esposte API pubbliche sul controller GRDB:
+  - `saveAssetData(assetId:data:mimeType:fileName:)`
+  - `loadAssetData(assetId:)`
+  - `openAssetStream(assetId:)`
+  - `assetURLIfPresent(assetId:)`
+  - `deleteAsset(assetId:)`
+  - `fetchAssetIfNeeded(assetId:)` (no-op per GRDB)
+- `createAssetAndAttach(...)` ora salva i dati su file storage e scrive solo metadati nel `payload` dell’`Entity(type:"asset")`.
+
+> Nella PR #3 verrà **droppata** la tabella `asset_blobs` tramite migrazione GRDB.

--- a/Sources/GraphNext/Init/GraphNext.swift
+++ b/Sources/GraphNext/Init/GraphNext.swift
@@ -44,6 +44,8 @@ public struct GraphNextConfig {
     public var preloadFromPersistence: Bool
     /// Se `true`, all’avvio esegue `pull()` e poi `push()` su ciascun backend.
     public var autoSyncOnLaunch: Bool
+    /// Quota massima per la cache file degli asset (in byte). 0 = disattivata. Default: 200 MB
+    public var assetCacheQuotaBytes: Int
     /// Strategia per derivare il nome dello store in funzione dell’account/logica d’istanza.
     public var storeNameForAccount: (AccountDescriptor) -> String
     /// Identificativo univoco dell’istanza (prefissi subscription/notifiche, telemetria, ecc.).
@@ -63,6 +65,7 @@ public struct GraphNextConfig {
         storeName: String = "GraphNext",
         preloadFromPersistence: Bool = true,
         autoSyncOnLaunch: Bool = false,
+        assetCacheQuotaBytes: Int = 200 * 1024 * 1024,
         storeNameForAccount: @escaping (AccountDescriptor) -> String = { descriptor in
             switch descriptor {
             case .localOnly:
@@ -85,6 +88,7 @@ public struct GraphNextConfig {
         self.storeName = storeName
         self.preloadFromPersistence = preloadFromPersistence
         self.autoSyncOnLaunch = autoSyncOnLaunch
+        self.assetCacheQuotaBytes = max(0, assetCacheQuotaBytes)
         self.storeNameForAccount = storeNameForAccount
         self.instanceID = instanceID
         self.makePersistence = makePersistence
@@ -127,6 +131,17 @@ public final class GraphNext: ObservableObject {
         if config.preloadFromPersistence,
            let preloader = (self.persistence as Any) as? GraphPersistencePreloader {
             try preloader.preload(into: self.store)
+        }
+
+        // 3.5) Configure default FileAssetStorage with configured quota (if caller has not set a custom storage)
+        do {
+            let base = try FileAssetStorage.makeDefaultBaseDirectory()
+            let storage = try FileAssetStorage(baseDirectory: base, quotaBytes: config.assetCacheQuotaBytes)
+            AssetStorageProvider.shared.setStorage(storage)
+        } catch {
+            #if DEBUG
+            print("GraphNext: failed to configure default FileAssetStorage with quota: \(error)")
+            #endif
         }
 
         // 4) Backend engines (delegato alla factory fornita nel config)

--- a/Sources/GraphNext/Model/AssetMetadata.swift
+++ b/Sources/GraphNext/Model/AssetMetadata.swift
@@ -5,16 +5,17 @@
 //  Created by Valerio Buriani on 23/08/25.
 //
 
-
 import Foundation
 
-public struct AssetMetadata: Equatable {
+/// Metadati minimi salvati nel payload di una `Entity` con `type: "asset"`.
+/// Usati da AssetStorage e da tutti i backend (GRDB/CoreData/CloudKit).
+public struct AssetMetadata: Codable, Equatable, Sendable {
     public let length: Int
     public let sha256: String
-    public let mimeType: String?
+    public let mimeType: String
     public let fileName: String?
 
-    public init(length: Int, sha256: String, mimeType: String?, fileName: String?) {
+    public init(length: Int, sha256: String, mimeType: String, fileName: String? = nil) {
         self.length = length
         self.sha256 = sha256
         self.mimeType = mimeType

--- a/Sources/GraphNext/Persistence/Assets/AssetService.swift
+++ b/Sources/GraphNext/Persistence/Assets/AssetService.swift
@@ -1,0 +1,54 @@
+//
+//  AssetService.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+import Foundation
+
+public enum AssetService {
+
+    @inline(__always)
+    private static var storage: AssetStorage { AssetStorageProvider.shared.storage }
+
+    @discardableResult
+    public static func save(assetId: UUID, data: Data, mimeType: String, fileName: String? = nil) throws -> AssetMetadata {
+        let sha = data.sha256Hex()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: mimeType, fileName: fileName)
+        _ = try storage.save(data: data, for: assetId, meta: meta)
+        return meta
+    }
+
+    public static func load(assetId: UUID) throws -> Data {
+        guard let stream = try storage.openRead(assetId: assetId) else {
+            throw NSError(domain: "GraphNext", code: 404, userInfo: [NSLocalizedDescriptionKey: "Asset not found locally"])
+        }
+        stream.open(); defer { stream.close() }
+        var out = Data()
+        var buf = [UInt8](repeating: 0, count: 256*1024)
+        while stream.hasBytesAvailable {
+            let n = stream.read(&buf, maxLength: buf.count)
+            if n <= 0 { break }
+            out.append(buf, count: n)
+        }
+        return out
+    }
+
+    public static func open(assetId: UUID) throws -> InputStream? {
+        try storage.openRead(assetId: assetId)
+    }
+
+    public static func urlIfPresent(assetId: UUID) throws -> URL? {
+        try storage.urlIfPresent(assetId: assetId)
+    }
+
+    public static func delete(assetId: UUID) throws {
+        try storage.remove(assetId: assetId)
+    }
+
+    public static func verify(assetId: UUID) throws -> Bool {
+        try storage.verifyChecksum(assetId: assetId)
+    }
+}

--- a/Sources/GraphNext/Persistence/Assets/AssetStorage.swift
+++ b/Sources/GraphNext/Persistence/Assets/AssetStorage.swift
@@ -1,0 +1,61 @@
+//
+//  AssetStorage.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+import Foundation
+import CryptoKit
+
+/// Errori specifici per la gestione file‑backed degli asset.
+public enum AssetStorageError: Error, LocalizedError {
+    case indexNotFound(UUID)
+    case contentNotFound(sha256: String)
+    case checksumMismatch
+    case ioError(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .indexNotFound(let id): return "Asset index not found for id \(id)"
+        case .contentNotFound(let sha): return "Asset content not found for sha256 \(sha)"
+        case .checksumMismatch: return "Computed checksum does not match expected sha256"
+        case .ioError(let underlying): return "I/O error: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// Interfaccia di storage per asset file‑backed.
+/// N.B.: l’implementazione default è `FileAssetStorage`.
+public protocol AssetStorage: Sendable {
+    /// Salva i bytes su disco, indicizzando l’asset `assetId` verso il contenuto content-addressed `sha256`.
+    /// Ritorna l’URL locale al file di contenuto (non all’indice).
+    func save(data: Data, for assetId: UUID, meta: AssetMetadata) throws -> URL
+
+    /// Stream in sola lettura per l’asset. Aggiorna il lastAccess nei metadati locali.
+    func openRead(assetId: UUID) throws -> InputStream?
+
+    /// URL locale del contenuto se presente (nil se mancante). Non scarica nulla.
+    func urlIfPresent(assetId: UUID) throws -> URL?
+
+    /// Verifica presenza di indice e contenuto locale.
+    func exists(assetId: UUID) throws -> Bool
+
+    /// Rimuove l’indice per `assetId`. Se nessun altro indice punta allo stesso `sha256`, rimuove anche il contenuto.
+    func remove(assetId: UUID) throws
+
+    /// Ricalcola lo SHA256 del contenuto locale puntato da `assetId` e lo confronta con quello atteso.
+    func verifyChecksum(assetId: UUID) throws -> Bool
+}
+
+// MARK: - Utilities
+
+extension Data {
+    /// SHA256 in esadecimale (lowercase).
+    public func sha256Hex() -> String {
+        var hasher = SHA256()
+        hasher.update(data: self)
+        let digest = hasher.finalize()
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/GraphNext/Persistence/Assets/AssetStorageProvider.swift
+++ b/Sources/GraphNext/Persistence/Assets/AssetStorageProvider.swift
@@ -5,7 +5,6 @@
 //  Created by Valerio Buriani on 24/08/25.
 //
 
-
 //
 //  AssetStorageProvider.swift
 //  GraphNext

--- a/Sources/GraphNext/Persistence/Assets/AssetStorageProvider.swift
+++ b/Sources/GraphNext/Persistence/Assets/AssetStorageProvider.swift
@@ -1,0 +1,41 @@
+//
+//  AssetStorageProvider.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+//
+//  AssetStorageProvider.swift
+//  GraphNext
+//
+//  Created by Regia GraphNext on 24/08/2025.
+//
+
+import Foundation
+
+/// Registry minimale per fornire un AssetStorage globale
+/// senza toccare i costruttori dei controller esistenti.
+/// In PR successive verrà “agganciato” a GraphNextConfig.
+public final class AssetStorageProvider: @unchecked Sendable {
+    public static let shared = AssetStorageProvider()
+
+    private var _storage: AssetStorage?
+    private let lock = NSLock()
+
+    public func setStorage(_ storage: AssetStorage) {
+        lock.lock(); defer { lock.unlock() }
+        _storage = storage
+    }
+
+    public var storage: AssetStorage {
+        lock.lock(); defer { lock.unlock() }
+        if let s = _storage { return s }
+        // default lazy
+        let url = (try? FileAssetStorage.makeDefaultBaseDirectory()) ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        let fileStore = (try? FileAssetStorage(baseDirectory: url)) ?? (try! FileAssetStorage(baseDirectory: URL(fileURLWithPath: NSTemporaryDirectory())))
+        _storage = fileStore
+        return fileStore
+    }
+}

--- a/Sources/GraphNext/Persistence/Assets/FileAssetStorage.swift
+++ b/Sources/GraphNext/Persistence/Assets/FileAssetStorage.swift
@@ -1,0 +1,232 @@
+//
+//  FileAssetStorage.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+import Foundation
+import CryptoKit
+
+/// Implementazione file‑backed:
+/// - contenuto content-addressed: `content/<aa>/<bb>/<sha256>`
+/// - indice per assetId:       `index/<assetId>.json`  -> { sha256, length, mimeType, fileName, lastAccess }
+///
+/// Vantaggi:
+/// - dedup automatico per sha256
+/// - open/url/exists risolti via indice assetId -> sha256
+/// - pronto per futura eviction LRU (usa lastAccess)
+public final class FileAssetStorage: AssetStorage {
+
+    // MARK: Types
+
+    private struct IndexRecord: Codable {
+        var sha256: String
+        var length: Int
+        var mimeType: String
+        var fileName: String?
+        var lastAccess: Date
+    }
+
+    // MARK: Paths
+
+    public let baseDirectory: URL
+    private let indexDir: URL
+    private let contentDir: URL
+    private let ioQueue = DispatchQueue(label: "FileAssetStorage.ioQueue", qos: .utility)
+
+    // MARK: Init
+
+    /// - Parameters:
+    ///   - baseDirectory: directory radice (es. Application Support / GraphNextAssets).
+    ///                    Se non esiste verrà creata.
+    public init(baseDirectory: URL) throws {
+        self.baseDirectory = baseDirectory
+        self.indexDir = baseDirectory.appendingPathComponent("index", isDirectory: true)
+        self.contentDir = baseDirectory.appendingPathComponent("content", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: indexDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: contentDir, withIntermediateDirectories: true)
+    }
+
+    /// Comodo factory che posiziona la directory in Application Support.
+    public static func makeDefaultBaseDirectory() throws -> URL {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        let root = try FileManager.default.url(for: .applicationSupportDirectory,
+                                               in: .userDomainMask,
+                                               appropriateFor: nil, create: true)
+        #else
+        let root = try FileManager.default.url(for: .applicationSupportDirectory,
+                                               in: .userDomainMask,
+                                               appropriateFor: nil, create: true)
+        #endif
+        return root.appendingPathComponent("GraphNextAssets", isDirectory: true)
+    }
+
+    // MARK: AssetStorage
+
+    public func save(data: Data, for assetId: UUID, meta: AssetMetadata) throws -> URL {
+        let computed = data.sha256Hex()
+        guard computed == meta.sha256 else {
+            throw AssetStorageError.checksumMismatch
+        }
+
+        return try performSync {
+            // 1) Scrivi contenuto (se non già presente)
+            let contentURL = self.contentURL(forSHA: meta.sha256)
+            if !FileManager.default.fileExists(atPath: contentURL.path) {
+                // Scrittura atomica
+                let tmp = contentURL.appendingPathExtension("tmp-\(UUID().uuidString)")
+                do {
+                    try data.write(to: tmp, options: .atomic)
+                    try FileManager.default.moveItem(at: tmp, to: contentURL)
+                } catch {
+                    // cleanup temporaneo, se esiste
+                    try? FileManager.default.removeItem(at: tmp)
+                    throw AssetStorageError.ioError(underlying: error)
+                }
+            }
+
+            // 2) Aggiorna/crea indice assetId -> sha256
+            let record = IndexRecord(
+                sha256: meta.sha256,
+                length: meta.length,
+                mimeType: meta.mimeType,
+                fileName: meta.fileName,
+                lastAccess: Date()
+            )
+            try self.writeIndex(record, for: assetId)
+            return contentURL
+        }
+    }
+
+    public func openRead(assetId: UUID) throws -> InputStream? {
+        try performSync {
+            guard var rec = try self.readIndex(for: assetId) else { return nil }
+            let contentURL = self.contentURL(forSHA: rec.sha256)
+            guard FileManager.default.fileExists(atPath: contentURL.path) else { return nil }
+
+            // Aggiorna lastAccess
+            rec.lastAccess = Date()
+            try self.writeIndex(rec, for: assetId)
+            return InputStream(url: contentURL)
+        }
+    }
+
+    public func urlIfPresent(assetId: UUID) throws -> URL? {
+        try performSync {
+            guard let rec = try self.readIndex(for: assetId) else { return nil }
+            let contentURL = self.contentURL(forSHA: rec.sha256)
+            return FileManager.default.fileExists(atPath: contentURL.path) ? contentURL : nil
+        }
+    }
+
+    public func exists(assetId: UUID) throws -> Bool {
+        try performSync {
+            guard let rec = try self.readIndex(for: assetId) else { return false }
+            let contentURL = self.contentURL(forSHA: rec.sha256)
+            return FileManager.default.fileExists(atPath: contentURL.path)
+        }
+    }
+
+    public func remove(assetId: UUID) throws {
+        try performSync {
+            guard let rec = try self.readIndex(for: assetId) else { return }
+            // 1) Rimuovi indice
+            try self.deleteIndex(for: assetId)
+            // 2) Se nessun altro indice punta allo stesso SHA, rimuovi il contenuto
+            if try !self.anyIndexPoints(toSHA: rec.sha256) {
+                let url = self.contentURL(forSHA: rec.sha256)
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
+    public func verifyChecksum(assetId: UUID) throws -> Bool {
+        try performSync {
+            guard let rec = try self.readIndex(for: assetId) else { return false }
+            let url = self.contentURL(forSHA: rec.sha256)
+            guard let stream = InputStream(url: url) else { return false }
+            stream.open()
+            defer { stream.close() }
+
+            var hasher = CryptoKit.SHA256()
+            let chunkSize = 256 * 1024
+            var buffer = [UInt8](repeating: 0, count: chunkSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(&buffer, maxLength: chunkSize)
+                if read < 0 { return false }
+                if read == 0 { break }
+                hasher.update(data: Data(buffer[0..<read]))
+            }
+            let digest = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+            return digest == rec.sha256
+        }
+    }
+
+    // MARK: Private helpers
+
+    private func performSync<T>(_ block: () throws -> T) rethrows -> T {
+        try ioQueue.sync(execute: block)
+    }
+
+    private func contentURL(forSHA sha: String) -> URL {
+        let a = String(sha.prefix(2))
+        let b = String(sha.dropFirst(2).prefix(2))
+        let dir = contentDir.appendingPathComponent(a, isDirectory: true)
+                             .appendingPathComponent(b, isDirectory: true)
+        // crea directory se necessario
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent(sha, isDirectory: false)
+    }
+
+    private func indexURL(for assetId: UUID) -> URL {
+        indexDir.appendingPathComponent(assetId.uuidString + ".json", isDirectory: false)
+    }
+
+    private func readIndex(for assetId: UUID) throws -> IndexRecord? {
+        let url = indexURL(for: assetId)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(IndexRecord.self, from: data)
+        } catch {
+            throw AssetStorageError.ioError(underlying: error)
+        }
+    }
+
+    private func writeIndex(_ rec: IndexRecord, for assetId: UUID) throws {
+        let url = indexURL(for: assetId)
+        do {
+            let data = try JSONEncoder().encode(rec)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw AssetStorageError.ioError(underlying: error)
+        }
+    }
+
+    private func deleteIndex(for assetId: UUID) throws {
+        let url = indexURL(for: assetId)
+        if FileManager.default.fileExists(atPath: url.path) {
+            do { try FileManager.default.removeItem(at: url) }
+            catch { throw AssetStorageError.ioError(underlying: error) }
+        }
+    }
+
+    private func anyIndexPoints(toSHA sha: String) throws -> Bool {
+        // Scansione veloce dell'intera cartella index; ok perché i record sono piccoli.
+        // (Ottimizzabile in futuro con una tabella di riferimento/contatore).
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: indexDir, includingPropertiesForKeys: nil) else {
+            return false
+        }
+        for file in files where file.pathExtension == "json" {
+            if let data = try? Data(contentsOf: file),
+               let rec = try? JSONDecoder().decode(IndexRecord.self, from: data),
+               rec.sha256 == sha {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Sources/GraphNext/Persistence/Assets/FileAssetStorage.swift
+++ b/Sources/GraphNext/Persistence/Assets/FileAssetStorage.swift
@@ -35,15 +35,19 @@ public final class FileAssetStorage: AssetStorage {
     private let contentDir: URL
     private let ioQueue = DispatchQueue(label: "FileAssetStorage.ioQueue", qos: .utility)
 
+    /// Quota cache (byte). Quando superata, scatta eviction LRU (best-effort). 0 = disattivata.
+    public let quotaBytes: Int
+
     // MARK: Init
 
     /// - Parameters:
     ///   - baseDirectory: directory radice (es. Application Support / GraphNextAssets).
     ///                    Se non esiste verrà creata.
-    public init(baseDirectory: URL) throws {
+    public init(baseDirectory: URL, quotaBytes: Int = 200 * 1024 * 1024) throws {
         self.baseDirectory = baseDirectory
         self.indexDir = baseDirectory.appendingPathComponent("index", isDirectory: true)
         self.contentDir = baseDirectory.appendingPathComponent("content", isDirectory: true)
+        self.quotaBytes = max(0, quotaBytes)
 
         try FileManager.default.createDirectory(at: indexDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: contentDir, withIntermediateDirectories: true)
@@ -96,6 +100,7 @@ public final class FileAssetStorage: AssetStorage {
                 lastAccess: Date()
             )
             try self.writeIndex(record, for: assetId)
+            try self.enforceQuotaIfNeeded()
             return contentURL
         }
     }
@@ -115,9 +120,17 @@ public final class FileAssetStorage: AssetStorage {
 
     public func urlIfPresent(assetId: UUID) throws -> URL? {
         try performSync {
-            guard let rec = try self.readIndex(for: assetId) else { return nil }
+            guard var rec = try self.readIndex(for: assetId) else { return nil }
             let contentURL = self.contentURL(forSHA: rec.sha256)
-            return FileManager.default.fileExists(atPath: contentURL.path) ? contentURL : nil
+            guard FileManager.default.fileExists(atPath: contentURL.path) else {
+                // file mancante: indice stale → pulizia
+                try? self.deleteIndex(for: assetId)
+                return nil
+            }
+            // touch LRU
+            rec.lastAccess = Date()
+            try self.writeIndex(rec, for: assetId)
+            return contentURL
         }
     }
 
@@ -228,5 +241,72 @@ public final class FileAssetStorage: AssetStorage {
             }
         }
         return false
+    }
+
+    // MARK: - LRU / Eviction
+
+    /// Restituisce tutti gli index record (assetId -> record).
+    private func readAllIndexRecords() -> [(UUID, IndexRecord)] {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: indexDir, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        var result: [(UUID, IndexRecord)] = []
+        for url in files where url.pathExtension == "json" {
+            let name = url.deletingPathExtension().lastPathComponent
+            guard let id = UUID(uuidString: name) else { continue }
+            if let data = try? Data(contentsOf: url),
+               let rec = try? JSONDecoder().decode(IndexRecord.self, from: data) {
+                result.append((id, rec))
+            }
+        }
+        return result
+    }
+
+    /// Calcola la dimensione totale dichiarata dagli index record.
+    private func totalSizeBytes() -> Int {
+        readAllIndexRecords().reduce(0) { $0 + $1.1.length }
+    }
+
+    /// Mappa sha256 -> numero di riferimenti negli index record.
+    private func shaRefCounts() -> [String: Int] {
+        var counts: [String: Int] = [:]
+        for (_, rec) in readAllIndexRecords() {
+            counts[rec.sha256, default: 0] += 1
+        }
+        return counts
+    }
+
+    /// Se la quota è superata, rimuove file partendo dai meno recenti (LRU) finché size <= quota.
+    private func enforceQuotaIfNeeded() throws {
+        guard quotaBytes > 0 else { return }
+        var currentSize = totalSizeBytes()
+        guard currentSize > quotaBytes else { return }
+
+        // Ordina per lastAccess crescente (più vecchi prima)
+        var all = readAllIndexRecords().sorted { $0.1.lastAccess < $1.1.lastAccess }
+        var ref = shaRefCounts()
+
+        while currentSize > quotaBytes, let victim = all.first {
+            let (assetId, rec) = victim
+            // Elimina index del victim
+            try? self.deleteIndex(for: assetId)
+            currentSize -= rec.length
+
+            // Se questo sha non è più referenziato, rimuovi il contenuto
+            if let c = ref[rec.sha256] {
+                let newC = c - 1
+                if newC <= 0 {
+                    let url = self.contentURL(forSHA: rec.sha256)
+                    try? FileManager.default.removeItem(at: url)
+                    ref[rec.sha256] = nil
+                } else {
+                    ref[rec.sha256] = newC
+                }
+            }
+
+            // Rimuovi l'elemento dalla lista e continua
+            all.removeFirst()
+        }
     }
 }

--- a/Sources/GraphNext/Persistence/Assets/LRUAssetIndex.swift
+++ b/Sources/GraphNext/Persistence/Assets/LRUAssetIndex.swift
@@ -1,0 +1,121 @@
+//
+//  LRUAssetIndex.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 25/08/25.
+//
+
+import Foundation
+
+/// Info tracciate per ogni asset nel catalogo cache.
+struct AssetCatalogEntry: Codable {
+    let assetId: UUID
+    var length: Int
+    var sha256: String
+    var mimeType: String?
+    var fileName: String?
+    /// Ultimo accesso (epoch seconds) per LRU
+    var lastAccess: TimeInterval
+}
+
+/// Indice LRU minimale, persistito su disco (JSON).
+/// Tiene traccia di `sizeBytes` totale e rimuove dal più vecchio in poi quando serve.
+final class LRUAssetIndex {
+    private var entries: [UUID: AssetCatalogEntry] = [:]
+    private(set) var sizeBytes: Int = 0
+
+    private let indexURL: URL
+    private let ioQueue = DispatchQueue(label: "LRUAssetIndex.io")
+
+    init(indexURL: URL) {
+        self.indexURL = indexURL
+        loadFromDiskIfPresent()
+    }
+
+    // MARK: - Public mutations (thread-safe tramite ioQueue)
+
+    func upsert(assetId: UUID, meta: AssetMetadata, lastAccess: Date = .init()) {
+        ioQueue.sync {
+            if let old = entries[assetId] {
+                // Adjust size if length changed
+                sizeBytes += (meta.length - old.length)
+                entries[assetId] = AssetCatalogEntry(
+                    assetId: assetId,
+                    length: meta.length,
+                    sha256: meta.sha256,
+                    mimeType: meta.mimeType,
+                    fileName: meta.fileName,
+                    lastAccess: lastAccess.timeIntervalSince1970
+                )
+            } else {
+                sizeBytes += meta.length
+                entries[assetId] = AssetCatalogEntry(
+                    assetId: assetId,
+                    length: meta.length,
+                    sha256: meta.sha256,
+                    mimeType: meta.mimeType,
+                    fileName: meta.fileName,
+                    lastAccess: lastAccess.timeIntervalSince1970
+                )
+            }
+            persist()
+        }
+    }
+
+    func markAccess(assetId: UUID, at date: Date = .init()) {
+        ioQueue.sync {
+            guard var e = entries[assetId] else { return }
+            e.lastAccess = date.timeIntervalSince1970
+            entries[assetId] = e
+            persist()
+        }
+    }
+
+    func remove(assetId: UUID) {
+        ioQueue.sync {
+            if let e = entries.removeValue(forKey: assetId) {
+                sizeBytes -= e.length
+                if sizeBytes < 0 { sizeBytes = 0 }
+                persist()
+            }
+        }
+    }
+
+    /// Restituisce gli asset in ordine di ultimo accesso ASC (i più vecchi prima)
+    func leastRecentlyUsedOrder() -> [AssetCatalogEntry] {
+        ioQueue.sync {
+            entries.values.sorted { $0.lastAccess < $1.lastAccess }
+        }
+    }
+
+    func snapshot() -> [UUID: AssetCatalogEntry] {
+        ioQueue.sync { entries }
+    }
+
+    // MARK: - Persistence
+
+    private func loadFromDiskIfPresent() {
+        ioQueue.sync {
+            guard FileManager.default.fileExists(atPath: indexURL.path) else { return }
+            do {
+                let data = try Data(contentsOf: indexURL)
+                let decoded = try JSONDecoder().decode([UUID: AssetCatalogEntry].self, from: data)
+                self.entries = decoded
+                self.sizeBytes = decoded.values.reduce(0) { $0 + $1.length }
+            } catch {
+                // Index corrotto: riparti da vuoto
+                self.entries = [:]
+                self.sizeBytes = 0
+            }
+        }
+    }
+
+    private func persist() {
+        do {
+            let data = try JSONEncoder().encode(entries)
+            try data.write(to: indexURL, options: [.atomic])
+        } catch {
+            // Best-effort: non bloccare il flusso per errori sulla persistenza dell'indice
+        }
+    }
+}

--- a/Sources/GraphNext/Persistence/CoreData/CoreDataGraphPersistenceController+Assets.swift
+++ b/Sources/GraphNext/Persistence/CoreData/CoreDataGraphPersistenceController+Assets.swift
@@ -1,0 +1,123 @@
+//
+//  CoreDataGraphPersistenceController+Assets.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/2025.
+//
+
+import Foundation
+
+extension CoreDataGraphPersistenceController {
+
+    // MARK: - File-backed Asset APIs (aligned with GRDB)
+
+    /// Salva (o sovrascrive) i bytes dell'asset `assetId` nello storage file-backed e ritorna i metadati.
+    @discardableResult
+    public func saveAssetData(
+        assetId: UUID,
+        data: Data,
+        mimeType: String,
+        fileName: String? = nil
+    ) async throws -> AssetMetadata {
+        let sha = data.sha256Hex()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: mimeType, fileName: fileName)
+        _ = try storage.save(data: data, for: assetId, meta: meta)
+        return meta
+    }
+
+    /// Carica interamente i bytes dell'asset da storage file-backed.
+    public func loadAssetData(assetId: UUID) async throws -> Data {
+        guard let stream = try storage.openRead(assetId: assetId) else {
+            throw NSError(domain: "GraphNext.CoreData", code: 404, userInfo: [NSLocalizedDescriptionKey: "Asset not found locally"])
+        }
+        stream.open()
+        defer { stream.close() }
+        var out = Data()
+        var buf = [UInt8](repeating: 0, count: 256 * 1024)
+        while stream.hasBytesAvailable {
+            let n = stream.read(&buf, maxLength: buf.count)
+            if n <= 0 { break }
+            out.append(buf, count: n)
+        }
+        return out
+    }
+
+    /// Stream di sola lettura dal file locale (utile per CKAsset o copie su disco).
+    public func openAssetStream(assetId: UUID) async throws -> InputStream? {
+        try storage.openRead(assetId: assetId)
+    }
+
+    /// URL locale se presente (non forza download/sync).
+    public func assetURLIfPresent(assetId: UUID) async throws -> URL? {
+        try storage.urlIfPresent(assetId: assetId)
+    }
+
+    /// Rimuove l’asset dallo storage file-backed (non rimuove l’Entity).
+    public func deleteAsset(assetId: UUID) async throws {
+        try storage.remove(assetId: assetId)
+    }
+
+    /// Hook per plugin di sync (CloudKit) che scaricano on‑demand il file quando serve.
+    /// Core Data: no‑op.
+    public func fetchAssetIfNeeded(assetId: UUID) async throws { }
+
+    // MARK: - Convenience: create + attach
+
+    /// Crea un'Entity `asset`, salva i bytes su file storage, e collega con Relationship `attaches` al proprietario.
+    public func createAssetAndAttach(
+        data: Data,
+        mimeType: String?,
+        fileName: String?,
+        attachTo ownerId: UUID
+    ) async throws -> Entity {
+
+        let mime = mimeType ?? "application/octet-stream"
+        let sha = data.sha256Hex()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: mime, fileName: fileName)
+
+        let assetId = UUID()
+        let asset = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "system", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string(mime),
+                "fileName": .string(fileName ?? ""),
+                "length": .int(meta.length),
+                "sha256": .string(meta.sha256)
+            ]
+        )
+
+        let link = Relationship(
+            id: UUID(),
+            type: "attaches",
+            tag: [],
+            group: [],
+            created: .init(by: "system", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [:],
+            from: ownerId,
+            to: asset.id
+        )
+
+        // Persisti Entity + Relationship (Core Data) e salva file su storage
+        try await saveEntity(asset)
+        _ = try storage.save(data: data, for: assetId, meta: meta)
+        try await saveRelationship(link)
+
+        return asset
+    }
+
+    // MARK: - Private
+
+    private var storage: AssetStorage { AssetStorageProvider.shared.storage }
+}

--- a/Sources/GraphNext/Persistence/CoreData/CoreDataGraphPersistenceController.swift
+++ b/Sources/GraphNext/Persistence/CoreData/CoreDataGraphPersistenceController.swift
@@ -11,6 +11,9 @@ import CoreData
 public final class CoreDataGraphPersistenceController {
     
     private let container: NSPersistentContainer
+    
+    // Assets helper
+    private var assetStorage: AssetStorage { AssetStorageProvider.shared.storage }
 
     public init(storeName: String = "GraphNext", inMemory: Bool = false) {
         guard let modelURL = Bundle.module.url(forResource: "GraphNext", withExtension: "momd"),
@@ -159,6 +162,10 @@ public final class CoreDataGraphPersistenceController {
         let semaphore = DispatchSemaphore(value: 0)
         container.performBackgroundTask { context in
             if let entity = self.fetchEntity(id: id, in: context) {
+                // Best-effort: if this is an asset entity, remove the local file before deleting from Core Data
+                if entity.type == "asset" {
+                    try? self.assetStorage.remove(assetId: id)
+                }
                 context.delete(entity)
             }
             if let relationship = self.fetchRelationship(id: id, in: context) {
@@ -222,6 +229,10 @@ public final class CoreDataGraphPersistenceController {
 
             // 2) Elimina l'entity se presente
             if let entity = try self.fetchCDEntity(id: id, in: context) {
+                // Best-effort: se è un asset, rimuovi il file locale prima della delete
+                if entity.type == "asset" {
+                    try? self.assetStorage.remove(assetId: id)
+                }
                 context.delete(entity)
             }
 

--- a/Sources/GraphNext/Persistence/GRDB/GRDBGraphPersistenceController+Assets.swift
+++ b/Sources/GraphNext/Persistence/GRDB/GRDBGraphPersistenceController+Assets.swift
@@ -3,6 +3,7 @@
 //  GraphNext
 //
 //  Created by Valerio Buriani on 23/08/25.
+//  Refactor file-backed by Regia GraphNext on 24/08/25
 //
 
 import Foundation
@@ -11,98 +12,89 @@ import GRDB
 
 extension GRDBGraphPersistenceController {
 
-    public func saveAssetBlob(
-        for assetId: UUID,
+    // MARK: - API pubbliche file-backed
+
+    /// Salva (o sovrascrive) i bytes dell'asset `assetId` su storage file-backed e ritorna i metadati.
+    /// Non tocca più il DB per i binari.
+    public func saveAssetData(
+        assetId: UUID,
         data: Data,
-        mimeType: String? = nil,
+        mimeType: String,
         fileName: String? = nil
     ) async throws -> AssetMetadata {
-        try await dbQueue.write { db in
-            let length = data.count
-            let sha256 = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        let sha = data.sha256Hex()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: mimeType, fileName: fileName)
+        _ = try storage.save(data: data, for: assetId, meta: meta)
+        return meta
+    }
 
-            try db.execute(sql: """
-                INSERT OR REPLACE INTO asset_blobs (entityId, data, length, sha256, mimeType, fileName)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                arguments: [
-                    assetId.uuidString,
-                    data,
-                    length,
-                    sha256,
-                    mimeType,
-                    fileName
-                ])
-
-            return AssetMetadata(length: length, sha256: sha256, mimeType: mimeType, fileName: fileName)
+    /// Carica interamente i bytes dell'asset da storage file-backed.
+    public func loadAssetData(assetId: UUID) async throws -> Data {
+        guard let stream = try storage.openRead(assetId: assetId) else {
+            throw NSError(domain: "GraphNext", code: 404, userInfo: [NSLocalizedDescriptionKey: "Asset not found locally"])
         }
+        stream.open()
+        defer { stream.close() }
+        var out = Data()
+        var buf = [UInt8](repeating: 0, count: 256*1024)
+        while stream.hasBytesAvailable {
+            let n = stream.read(&buf, maxLength: buf.count)
+            if n < 0 { break }
+            if n == 0 { break }
+            out.append(buf, count: n)
+        }
+        return out
+    }
+
+    /// Stream di sola lettura dal file locale (comodo per CKAsset o copie su disco).
+    public func openAssetStream(assetId: UUID) async throws -> InputStream? {
+        try storage.openRead(assetId: assetId)
+    }
+
+    /// URL locale se presente (non forza download/sync).
+    public func assetURLIfPresent(assetId: UUID) async throws -> URL? {
+        try storage.urlIfPresent(assetId: assetId)
+    }
+
+    /// Rimuove l’asset dal file storage. Non rimuove l’Entity; per quello usa deleteEntity(_:)
+    public func deleteAsset(assetId: UUID) async throws {
+        try storage.remove(assetId: assetId)
+    }
+
+    /// Hook per plugin di sync (CloudKit) che scaricano on‑demand il file quando serve.
+    /// Implementazione GRDB: no‑op, ritorna subito.
+    public func fetchAssetIfNeeded(assetId: UUID) async throws {
+        // no-op per GRDB: lo storage locale non scarica da remoto.
+        // Il plugin CloudKit farà override/usando un service specifico.
+    }
+
+    // MARK: - Helper
+
+    private var storage: AssetStorage {
+        AssetStorageProvider.shared.storage
     }
 }
 
-extension GRDBGraphPersistenceController {
-
-    public func loadAssetBlob(for assetId: UUID) async throws -> (data: Data, meta: AssetMetadata) {
-        try await dbQueue.read { db in
-            guard let row = try Row.fetchOne(
-                db,
-                sql: """
-                    SELECT data, length, sha256, mimeType, fileName
-                    FROM asset_blobs
-                    WHERE entityId = ?
-                    """,
-                arguments: [assetId.uuidString]
-            ) else {
-                throw NSError(domain: "GraphNext", code: 404, userInfo: [NSLocalizedDescriptionKey: "Asset not found"])
-            }
-
-            guard let data: Data = row["data"] else {
-                throw NSError(domain: "GraphNext", code: 500, userInfo: [NSLocalizedDescriptionKey: "Asset data corrupted"])
-            }
-
-            let length: Int = row["length"]
-            let sha256: String = row["sha256"]
-            let mimeType: String? = row["mimeType"]
-            let fileName: String? = row["fileName"]
-
-            return (
-                data,
-                AssetMetadata(length: length, sha256: sha256, mimeType: mimeType, fileName: fileName)
-            )
-        }
-    }
-}
+// MARK: - Convenience: createAssetAndAttach (file-backed)
 
 extension GRDBGraphPersistenceController {
 
-    public func deleteAssetBlob(for assetId: UUID) async throws {
-        try await dbQueue.write { db in
-            try db.execute(
-                sql: "DELETE FROM asset_blobs WHERE entityId = ?",
-                arguments: [assetId.uuidString]
-            )
-        }
-    }
-}
-
-extension GRDBGraphPersistenceController {
+    /// Crea un'Entity `asset`, salva i bytes su file storage, e collega con Relationship `attaches` al proprietario.
     public func createAssetAndAttach(
         data: Data,
         mimeType: String?,
         fileName: String?,
         attachTo ownerId: UUID
     ) async throws -> Entity {
-        // 1. Calcolo metadati
-        let sha256 = SHA256.hash(data: data).compactMap { String(format: "%02x", $0) }.joined()
-        let meta = AssetMetadata(
-            length: data.count,
-            sha256: sha256,
-            mimeType: mimeType,
-            fileName: fileName
-        )
 
-        // 2. Crea Entity asset
+        // 1) Metadati e Entity asset
+        let mime = mimeType ?? "application/octet-stream"
+        let sha = data.sha256Hex()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: mime, fileName: fileName)
+
+        let assetId = UUID()
         let asset = Entity(
-            id: UUID(),
+            id: assetId,
             type: "asset",
             tag: [],
             group: [],
@@ -112,14 +104,13 @@ extension GRDBGraphPersistenceController {
             sharedWith: [],
             permissions: nil,
             payload: [
-                "mimeType": .string(mimeType ?? ""),
+                "mimeType": .string(mime),
                 "fileName": .string(fileName ?? ""),
-                "length": .int(data.count),
-                "sha256": .string(sha256)
+                "length": .int(meta.length),
+                "sha256": .string(meta.sha256)
             ]
         )
 
-        // 3. Crea Relationship
         let link = Relationship(
             id: UUID(),
             type: "attaches",
@@ -135,9 +126,9 @@ extension GRDBGraphPersistenceController {
             to: asset.id
         )
 
-        // 4. Salva tutto
+        // 2) Persisti Entity + Relationship (DB), e salva file su storage
         try await saveEntity(asset)
-        _ = try await saveAssetBlob(for: asset.id, data: data, mimeType: mimeType, fileName: fileName)
+        _ = try storage.save(data: data, for: assetId, meta: meta)
         try await saveRelationship(link)
 
         return asset

--- a/Sources/GraphNext/Persistence/GRDB/GRDBGraphPersistenceController.swift
+++ b/Sources/GraphNext/Persistence/GRDB/GRDBGraphPersistenceController.swift
@@ -11,6 +11,9 @@ import GRDB
 public final class GRDBGraphPersistenceController: GraphPersistenceController {
     
     internal let dbQueue: DatabaseQueue
+    
+    // Assets helper
+    private var assetStorage: AssetStorage { AssetStorageProvider.shared.storage }
 
     public init(path: String, inMemory: Bool = false) throws {
         var config = Configuration()
@@ -68,6 +71,13 @@ public final class GRDBGraphPersistenceController: GraphPersistenceController {
     }
 
     public func deleteEntity(id: UUID) async throws {
+        // Pre-fetch: capiamo se è un asset
+        let existing = try await entity(id: id)
+        if existing?.type == "asset" {
+            // Best-effort: rimuovi file e indice locale (non bloccare la cancellazione DB se fallisce)
+            try? assetStorage.remove(assetId: id)
+        }
+        // Poi elimina da DB (relationships + entity)
         try await dbQueue.write { db in
             try db.execute(sql: "DELETE FROM relationships WHERE fromId = ? OR toId = ?", arguments: [id.uuidString, id.uuidString])
             try db.execute(sql: "DELETE FROM entities WHERE id = ?", arguments: [id.uuidString])
@@ -114,13 +124,32 @@ public final class GRDBGraphPersistenceController: GraphPersistenceController {
 
     public func deleteEntities(_ ids: [UUID]) async throws {
         guard !ids.isEmpty else { return }
+
+        // Pre-fetch per individuare quali sono asset
+        var assetIDs: [UUID] = []
+        for id in ids {
+            if let e = try await entity(id: id), e.type == "asset" {
+                assetIDs.append(id)
+            }
+        }
+
+        // Best-effort: rimuovi i file locali degli asset
+        for assetId in assetIDs {
+            try? assetStorage.remove(assetId: assetId)
+        }
+
+        // Cancella da DB (relationships + entities)
         let strings = ids.map(\.uuidString)
         let placeholders = Array(repeating: "?", count: strings.count).joined(separator: ",")
         try await dbQueue.write { db in
-            // First remove relationships that reference these entities
-            try db.execute(sql: "DELETE FROM relationships WHERE fromId IN (\(placeholders)) OR toId IN (\(placeholders))", arguments: StatementArguments(strings + strings))
-            // Then remove the entities
-            try db.execute(sql: "DELETE FROM entities WHERE id IN (\(placeholders))", arguments: StatementArguments(strings))
+            try db.execute(
+                sql: "DELETE FROM relationships WHERE fromId IN (\(placeholders)) OR toId IN (\(placeholders))",
+                arguments: StatementArguments(strings + strings)
+            )
+            try db.execute(
+                sql: "DELETE FROM entities WHERE id IN (\(placeholders))",
+                arguments: StatementArguments(strings)
+            )
         }
     }
 

--- a/Sources/GraphNext/Persistence/GRDB/Migrations.swift
+++ b/Sources/GraphNext/Persistence/GRDB/Migrations.swift
@@ -18,18 +18,12 @@ enum GraphDBMigrations {
             try GraphDBSchema.createRelationships(in: db)
         }
         
-        migrator.registerMigration("createAssetBlobs") { db in
-            try db.execute(sql: """
-                CREATE TABLE asset_blobs (
-                    entityId TEXT PRIMARY KEY
-                        REFERENCES entities(id) ON DELETE CASCADE,
-                    data     BLOB NOT NULL,
-                    length   INTEGER NOT NULL,
-                    sha256   TEXT NOT NULL,
-                    mimeType TEXT,
-                    fileName TEXT
-                )
-                """)
+
+        migrator.registerMigration("drop_legacy_asset_blobs_if_exists") { db in
+            // Safe cleanup for pre-PR2 development databases
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_asset_blobs_entityId;")
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_asset_blobs_sha256;")
+            try db.execute(sql: "DROP TABLE IF EXISTS asset_blobs;")
         }
 
         return migrator

--- a/Sources/GraphNext/Store/GraphStore.swift
+++ b/Sources/GraphNext/Store/GraphStore.swift
@@ -109,6 +109,15 @@ public final class GraphStore: @preconcurrency ObservableObject {
         return toIDs.compactMap { entities[$0] }
     }
     
+    /// Segnala in modo esplicito che l'asset con `id` è pronto localmente (file disponibile).
+    /// Questo helper è pensato per plugin come CloudKit: emette un `.update` via Combine
+    /// senza modificare i dati, così la UI/consumatori possono aggiornarsi.
+    public func notifyAssetReady(_ id: UUID) {
+        if let e = entity(id: id) {
+            update(node: e, isRemote: true)
+        }
+    }
+    
     public func clear(isRemote: Bool = false) {
         for entity in entities.values {
             remove(id: entity.id, isRemote: isRemote)

--- a/Sources/GraphNext/Sync/CloudKit/CKRecord+GraphNext.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CKRecord+GraphNext.swift
@@ -18,6 +18,12 @@ extension Entity {
             record["payload"] = payloadData as CKRecordValue
         }
         
+        // Attach CKAsset for file-backed assets, if a local URL is available.
+        if self.type == "asset" {
+            if let fileURL = try? AssetStorageProvider.shared.storage.urlIfPresent(assetId: self.id) {
+                record["file"] = CKAsset(fileURL: fileURL)
+            }
+        }
         
         record["sharedWith"] = self.sharedWith as CKRecordValue
         
@@ -59,4 +65,3 @@ extension Relationship {
         return record
     }
 }
-

--- a/Sources/GraphNext/Sync/CloudKit/CKRecord+GraphNext.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CKRecord+GraphNext.swift
@@ -8,6 +8,12 @@
 import CloudKit
 import Foundation
 
+/// Global threshold (bytes) to decide whether to attach CKAsset on push.
+/// Set from CloudKitSync.configuration.assetThresholdBytes at CloudKitSync init.
+enum _CKAttachmentThreshold {
+    static var bytes: Int = 15 * 1024 * 1024 // default 15 MB
+}
+
 extension Entity {
     func asCKRecord() -> CKRecord {
         let record = CKRecord(recordType: "Entity", recordID: CKRecord.ID(recordName: self.id.uuidString))
@@ -18,10 +24,18 @@ extension Entity {
             record["payload"] = payloadData as CKRecordValue
         }
         
-        // Attach CKAsset for file-backed assets, if a local URL is available.
+        // Attach CKAsset for file-backed assets, if a local URL is available and under threshold.
         if self.type == "asset" {
             if let fileURL = try? AssetStorageProvider.shared.storage.urlIfPresent(assetId: self.id) {
-                record["file"] = CKAsset(fileURL: fileURL)
+                if let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey]),
+                   let size = values.fileSize,
+                   size <= _CKAttachmentThreshold.bytes {
+                    record["file"] = CKAsset(fileURL: fileURL)
+                } else {
+                    // Over threshold or unknown size: keep only metadata in payload
+                    // (intentionally skip attaching CKAsset)
+                    print("Asset over threshold: \(fileURL), skipping attachment")
+                }
             }
         }
         

--- a/Sources/GraphNext/Sync/CloudKit/CloudKitAttachmentPolicy.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CloudKitAttachmentPolicy.swift
@@ -1,0 +1,20 @@
+//
+//  CloudKitAttachmentPolicy.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 25/08/25.
+//
+
+import Foundation
+
+/// Policy globale e banalissima per decidere se allegare il file al CKRecord.
+/// CloudKitSync setterà questa soglia leggendo `configuration.assetThresholdBytes`.
+enum CloudKitAttachmentPolicy {
+    private static var _thresholdBytes: Int = 15 * 1024 * 1024 // default 15 MB
+
+    static func setThresholdBytes(_ bytes: Int) {
+        _thresholdBytes = max(0, bytes)
+    }
+
+    static var thresholdBytes: Int { _thresholdBytes }
+}

--- a/Sources/GraphNext/Sync/CloudKit/CloudKitSync+Assets.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CloudKitSync+Assets.swift
@@ -1,0 +1,131 @@
+//
+//  CloudKitSync+Assets.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/2025.
+//
+
+import Foundation
+import CloudKit
+
+extension CloudKitSync {
+
+    // MARK: - Public API
+
+    public func fetchAssetIfNeeded(assetId: UUID) async throws {
+        // 1) Se il file è già presente, no-op
+        if let _ = try? AssetStorageProvider.shared.storage.urlIfPresent(assetId: assetId) {
+            return
+        }
+
+        // 2) Test hook: bypass CloudKit se impostato
+        if let hook = CloudKitTestHooks.fetchAssetRecord, let record = hook(assetId) {
+            try await Self._saveAssetFromRecord(record, assetId: assetId)
+            return
+        }
+
+        // 3) Fetch reale da CloudKit (solo chiave "file")
+        let (db, zoneID) = makeDatabaseAndZone()
+        let recordID = CKRecord.ID(recordName: assetId.uuidString, zoneID: zoneID)
+
+        let record: CKRecord = try await withCheckedThrowingContinuation { cont in
+            let op = CKFetchRecordsOperation(recordIDs: [recordID])
+            op.desiredKeys = ["file"]
+
+            var fetched: CKRecord?
+            op.perRecordResultBlock = { id, result in
+                if case let .success(rec) = result, id == recordID {
+                    fetched = rec
+                }
+            }
+
+            op.fetchRecordsResultBlock = { result in
+                switch result {
+                case .success:
+                    if let rec = fetched {
+                        cont.resume(returning: rec)
+                    } else {
+                        cont.resume(throwing: NSError(
+                            domain: "GraphNext.CloudKit",
+                            code: 404,
+                            userInfo: [NSLocalizedDescriptionKey: "CKRecord not found for asset \(assetId)"]
+                        ))
+                    }
+                case .failure(let error):
+                    cont.resume(throwing: error)
+                }
+            }
+
+            db.add(op)
+        }
+
+        try await Self._saveAssetFromRecord(record, assetId: assetId)
+    }
+
+    public func fetchAssetIfNeeded(assetId: UUID, store: GraphStore?) async throws {
+        try await fetchAssetIfNeeded(assetId: assetId)
+        guard let store = store else { return }
+        await MainActor.run {
+            store.notifyAssetReady(assetId)
+        }
+    }
+
+    public func fetchAssetIfNeededAndNotify(assetId: UUID) async throws {
+        try await fetchAssetIfNeeded(assetId: assetId, store: self.store)
+    }
+
+    // MARK: - Helpers
+
+    private static func _saveAssetFromRecord(_ record: CKRecord, assetId: UUID) async throws {
+        guard let ckAsset = record["file"] as? CKAsset, let remoteURL = ckAsset.fileURL else {
+            throw NSError(
+                domain: "GraphNext.CloudKit",
+                code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "No CKAsset 'file' for asset \(assetId)"]
+            )
+        }
+
+        guard let stream = InputStream(url: remoteURL) else {
+            throw NSError(
+                domain: "GraphNext.CloudKit",
+                code: 500,
+                userInfo: [NSLocalizedDescriptionKey: "Unable to open stream for CKAsset file URL"]
+            )
+        }
+
+        var bytes = Data()
+        bytes.reserveCapacity(256 * 1024)
+        stream.open()
+        defer { stream.close() }
+
+        var buffer = [UInt8](repeating: 0, count: 256 * 1024)
+        while stream.hasBytesAvailable {
+            let n = stream.read(&buffer, maxLength: buffer.count)
+            if n < 0 {
+                throw stream.streamError ?? NSError(
+                    domain: "GraphNext.CloudKit",
+                    code: 500,
+                    userInfo: [NSLocalizedDescriptionKey: "Stream read error"]
+                )
+            }
+            if n == 0 { break }
+            bytes.append(buffer, count: n)
+        }
+
+        let sha = bytes.sha256Hex()
+        let meta = AssetMetadata(length: bytes.count, sha256: sha, mimeType: "application/octet-stream", fileName: nil)
+        _ = try AssetStorageProvider.shared.storage.save(data: bytes, for: assetId, meta: meta)
+    }
+
+    private func makeDatabaseAndZone() -> (CKDatabase, CKRecordZone.ID) {
+        let container: CKContainer = {
+            if let id = configuration.containerIdentifier {
+                return CKContainer(identifier: id)
+            } else {
+                return CKContainer.default()
+            }
+        }()
+        let zoneID = CKRecordZone.ID(zoneName: configuration.zoneName, ownerName: CKCurrentUserDefaultName)
+        return (container.privateCloudDatabase, zoneID)
+    }
+}

--- a/Sources/GraphNext/Sync/CloudKit/CloudKitSync.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CloudKitSync.swift
@@ -87,6 +87,7 @@ public final class CloudKitSync: GraphSyncEngine {
         self.persistence = persistence
         self.store = store
         self.configuration = configuration
+        _CKAttachmentThreshold.bytes = max(0, configuration.assetThresholdBytes)
         self.pullDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)
         self.syncDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)
         self.pushDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)
@@ -122,6 +123,7 @@ public final class CloudKitSync: GraphSyncEngine {
         self.persistence = persistence
         self.store = store
         self.configuration = configuration
+        _CKAttachmentThreshold.bytes = max(0, configuration.assetThresholdBytes)
         self.pullDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)
         self.syncDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)
         self.pushDebouncer = AsyncDebouncer(milliseconds: configuration.debounceMilliseconds)

--- a/Sources/GraphNext/Sync/CloudKit/CloudKitSyncConfig.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CloudKitSyncConfig.swift
@@ -29,6 +29,8 @@ public struct CloudKitSyncConfig: Codable, Equatable {
     public var retryMaxAttempts: Int
     /// Delay base (secondi) per exponential backoff. Default: 0.5s
     public var retryBaseDelaySeconds: Double
+    /// Soglia dimensionale (byte) sotto la quale alleghiamo il CKAsset direttamente nel push. Default: 15 MB
+    public var assetThresholdBytes: Int
 
     public init(
         containerIdentifier: String? = nil,
@@ -39,6 +41,7 @@ public struct CloudKitSyncConfig: Codable, Equatable {
         debounceMilliseconds: Int = 750,
         retryMaxAttempts: Int = 3,
         retryBaseDelaySeconds: Double = 0.5,
+        assetThresholdBytes: Int = 15 * 1024 * 1024,
         pushBatchSize: Int = 100,
         pushMaxIntervalSeconds: Double = 3.0
     ) {
@@ -50,6 +53,7 @@ public struct CloudKitSyncConfig: Codable, Equatable {
         self.debounceMilliseconds = debounceMilliseconds
         self.retryMaxAttempts = retryMaxAttempts
         self.retryBaseDelaySeconds = retryBaseDelaySeconds
+        self.assetThresholdBytes = max(0, assetThresholdBytes)
         self.pushBatchSize = max(1, pushBatchSize)
         self.pushMaxIntervalSeconds = max(0.1, pushMaxIntervalSeconds)
     }

--- a/Sources/GraphNext/Sync/CloudKit/CloudKitTestHooks.swift
+++ b/Sources/GraphNext/Sync/CloudKit/CloudKitTestHooks.swift
@@ -1,0 +1,18 @@
+//
+//  CloudKitTestHooks.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+import Foundation
+import CloudKit
+
+/// Test hooks per permettere ai test di iniettare risposte finte da CloudKit
+/// senza andare in rete o dover subclassare tipi di CloudKit.
+enum CloudKitTestHooks {
+    /// Se impostata, `CloudKitSync.fetchAssetIfNeeded` userà questa closure
+    /// per ottenere un CKRecord per l’asset richiesto invece di contattare CloudKit.
+    static var fetchAssetRecord: ((UUID) -> CKRecord?)?
+}

--- a/Tests/GraphNextTests/Assets/AssetEvictionLRUTests.swift
+++ b/Tests/GraphNextTests/Assets/AssetEvictionLRUTests.swift
@@ -1,0 +1,75 @@
+// Tests/GraphNextTests/Assets/AssetEvictionLRUTests.swift
+//
+//  AssetEvictionLRUTests.swift
+//  GraphNextTests
+//
+//  Created by Regia GraphNext on 25/08/2025.
+//
+
+import XCTest
+@testable import GraphNext
+
+final class AssetEvictionLRUTests: XCTestCase {
+
+    private func makeIsolatedStorage(quotaBytes: Int) throws -> FileAssetStorage {
+        let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_LRU_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let storage = try FileAssetStorage(baseDirectory: base, quotaBytes: quotaBytes)
+        // setStorage NON lancia: niente `try` qui
+        AssetStorageProvider.shared.setStorage(storage)
+        return storage
+    }
+
+    func testEvictsLeastRecentlyUsedWhenQuotaExceeded() throws {
+        // Quota molto piccola: 10 byte
+        let storage = try makeIsolatedStorage(quotaBytes: 10)
+
+        // Tre asset: 6 + 4 + 4 = 14 > 10 → deve cadere il più vecchio
+        let a1 = UUID(), a2 = UUID(), a3 = UUID()
+        let d1 = Data("AAAAAA".utf8) // 6
+        let d2 = Data("BBBB".utf8)   // 4
+        let d3 = Data("CCCC".utf8)   // 4
+
+        _ = try storage.save(data: d1, for: a1, meta: .init(length: d1.count, sha256: d1.sha256Hex(), mimeType: "text/plain", fileName: "a1"))
+        _ = try storage.save(data: d2, for: a2, meta: .init(length: d2.count, sha256: d2.sha256Hex(), mimeType: "text/plain", fileName: "a2"))
+
+        // Tocchiamo a2 per renderlo più “recente”
+        _ = try storage.urlIfPresent(assetId: a2)
+
+        // Salvataggio che supera quota → evict LRU (a1)
+        _ = try storage.save(data: d3, for: a3, meta: .init(length: d3.count, sha256: d3.sha256Hex(), mimeType: "text/plain", fileName: "a3"))
+
+        // a1 dovrebbe essere stato rimosso
+        XCTAssertNil(try storage.urlIfPresent(assetId: a1))
+        // a2 e a3 presenti
+        XCTAssertNotNil(try storage.urlIfPresent(assetId: a2))
+        XCTAssertNotNil(try storage.urlIfPresent(assetId: a3))
+    }
+
+    func testAccessRefreshesLRU() throws {
+        let storage = try makeIsolatedStorage(quotaBytes: 10)
+
+        let a1 = UUID(), a2 = UUID()
+        let d1 = Data("AAAA".utf8)   // 4
+        let d2 = Data("BBBBBB".utf8) // 6 → totale 10, in quota
+
+        _ = try storage.save(data: d1, for: a1, meta: .init(length: d1.count, sha256: d1.sha256Hex(), mimeType: "text/plain", fileName: "a1"))
+        _ = try storage.save(data: d2, for: a2, meta: .init(length: d2.count, sha256: d2.sha256Hex(), mimeType: "text/plain", fileName: "a2"))
+
+        // Tocchiamo a1 (diventa il più “recente”)
+        _ = try storage.urlIfPresent(assetId: a1)
+
+        // Aggiungiamo un terzo asset da 4 → 14 > 10: evict quello meno recente (a2)
+        let a3 = UUID()
+        let d3 = Data("CCCC".utf8)   // 4
+        _ = try storage.save(data: d3, for: a3, meta: .init(length: d3.count, sha256: d3.sha256Hex(), mimeType: "text/plain", fileName: "a3"))
+
+        // a1 deve restare (è stato toccato)
+        XCTAssertNotNil(try storage.urlIfPresent(assetId: a1))
+        // a2 deve essere rimosso
+        XCTAssertNil(try storage.urlIfPresent(assetId: a2))
+        // a3 presente
+        XCTAssertNotNil(try storage.urlIfPresent(assetId: a3))
+    }
+}

--- a/Tests/GraphNextTests/Assets/CoreDataFileBackedAssetsTests.swift
+++ b/Tests/GraphNextTests/Assets/CoreDataFileBackedAssetsTests.swift
@@ -20,7 +20,7 @@ final class CoreDataFileBackedAssetsTests: XCTestCase {
         let assetsDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("GN_Assets_CD_\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
-        try AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: assetsDir))
+        AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: assetsDir))
     }
 
     func testCreateAttachAndRoundTrip_CoreData() async throws {

--- a/Tests/GraphNextTests/Assets/CoreDataFileBackedAssetsTests.swift
+++ b/Tests/GraphNextTests/Assets/CoreDataFileBackedAssetsTests.swift
@@ -1,0 +1,131 @@
+//
+//  CoreDataFileBackedAssetsTests.swift
+//  GraphNextTests
+//
+//  Created by Regia GraphNext on 24/08/2025.
+//
+
+import XCTest
+@testable import GraphNext
+
+final class CoreDataFileBackedAssetsTests: XCTestCase {
+
+    private func makeController() throws -> CoreDataGraphPersistenceController {
+        // Usa lo store in-memory come nel tuo controller
+        return CoreDataGraphPersistenceController(storeName: "GN_Test_CD", inMemory: true)
+    }
+
+    private func isolateStorage() throws {
+        // Isola l’AssetStorage in una cartella temp per non inquinare altri test
+        let assetsDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_CD_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
+        try AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: assetsDir))
+    }
+
+    func testCreateAttachAndRoundTrip_CoreData() async throws {
+        try isolateStorage()
+        let controller = try makeController()
+
+        // Owner entity
+        let owner = Entity(
+            id: UUID(),
+            type: "doc",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [:]
+        )
+        try await controller.saveEntity(owner)
+
+        // Dati finti (header PDF)
+        let data = Data([0x25, 0x50, 0x44, 0x46])
+        let asset = try await controller.createAssetAndAttach(
+            data: data,
+            mimeType: "application/pdf",
+            fileName: "cd-sample.pdf",
+            attachTo: owner.id
+        )
+
+        // URL presente?
+        let url = try await controller.assetURLIfPresent(assetId: asset.id)
+        XCTAssertNotNil(url, "URL locale dovrebbe esistere dopo il salvataggio")
+
+        // Load bytes e verifica
+        let loaded = try await controller.loadAssetData(assetId: asset.id)
+        XCTAssertEqual(loaded, data)
+
+        // Verify checksum
+        let ok = try AssetStorageProvider.shared.storage.verifyChecksum(assetId: asset.id)
+        XCTAssertTrue(ok, "Checksum dovrebbe combaciare")
+
+        // Delete SOLO file (non entity)
+        try await controller.deleteAsset(assetId: asset.id)
+        let afterDeleteURL = try await controller.assetURLIfPresent(assetId: asset.id)
+        XCTAssertNil(afterDeleteURL, "URL dovrebbe essere nil dopo la delete del file")
+    }
+
+    func testCascadeDeleteAlsoRemovesFile_CoreData() async throws {
+        try isolateStorage()
+        let controller = try makeController()
+
+        let asset = try await controller.createAssetAndAttach(
+            data: Data("to be deleted".utf8),
+            mimeType: "text/plain",
+            fileName: "delete.txt",
+            attachTo: UUID()
+        )
+
+        // Cancella l'entity asset → il file deve sparire grazie al best‑effort nel controller
+        try await controller.deleteEntity(id: asset.id)
+        let urlAfterDelete = try await controller.assetURLIfPresent(assetId: asset.id)
+        XCTAssertNil(urlAfterDelete, "Ci si aspetta che il file asset sia stato rimosso dallo storage locale")
+    }
+
+    func testSaveAssetDataUpdatesContentAndMetadata_CoreData() async throws {
+        try isolateStorage()
+        let controller = try makeController()
+
+        // Crea asset "vuoto" salvando direttamente i dati e poi costruendo l'entity.
+        let assetId = UUID()
+        let bytesV1 = Data("v1".utf8)
+        _ = try await controller.saveAssetData(assetId: assetId, data: bytesV1, mimeType: "text/plain", fileName: "note.txt")
+
+        // Crea l’Entity(type:"asset") con metadati coerenti
+        let assetEntity = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string("text/plain"),
+                "fileName": .string("note.txt"),
+                "length": .int(bytesV1.count),
+                "sha256": .string(bytesV1.sha256Hex())
+            ]
+        )
+        try await controller.saveEntity(assetEntity)
+
+        // Aggiorna i bytes
+        let bytesV2 = Data("v2-updated".utf8)
+        let meta = try await controller.saveAssetData(assetId: assetId, data: bytesV2, mimeType: "text/plain", fileName: "note.txt")
+        XCTAssertEqual(meta.length, bytesV2.count)
+
+        // Load: deve riflettere la V2
+        let loaded = try await controller.loadAssetData(assetId: assetId)
+        XCTAssertEqual(loaded, bytesV2)
+
+        // URL presente
+        let finalURL = try await controller.assetURLIfPresent(assetId: assetId)
+        XCTAssertNotNil(finalURL)
+    }
+}

--- a/Tests/GraphNextTests/Assets/FileAssetStorageTests.swift
+++ b/Tests/GraphNextTests/Assets/FileAssetStorageTests.swift
@@ -1,0 +1,99 @@
+//
+//  FileAssetStorageTests.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+//
+//  FileAssetStorageTests.swift
+//  GraphNextTests
+//
+//  Created by Regia GraphNext on 24/08/2025.
+//
+
+import XCTest
+@testable import GraphNext
+
+final class FileAssetStorageTests: XCTestCase {
+
+    private func makeTempDir() throws -> URL {
+        let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    func testRoundTrip_Save_Open_Verify_Remove() throws {
+        let tmp = try makeTempDir()
+        let storage = try FileAssetStorage(baseDirectory: tmp)
+
+        // piccoli sample bytes (PNG header + qualche byte)
+        let bytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x11, 0x22, 0x33])
+        let sha = bytes.sha256Hex()
+        let meta = AssetMetadata(length: bytes.count, sha256: sha, mimeType: "image/png", fileName: "sample.png")
+        let assetId = UUID()
+
+        // save
+        let url = try storage.save(data: bytes, for: assetId, meta: meta)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        // exists + urlIfPresent
+        XCTAssertTrue(try storage.exists(assetId: assetId))
+        XCTAssertEqual(try storage.urlIfPresent(assetId: assetId)?.path, url.path)
+
+        // openRead + verifyChecksum
+        let stream = try XCTUnwrap(try storage.openRead(assetId: assetId))
+        stream.open()
+        var readback = Data()
+        var buffer = [UInt8](repeating: 0, count: 64)
+        while stream.hasBytesAvailable {
+            let n = stream.read(&buffer, maxLength: buffer.count)
+            if n <= 0 { break }
+            readback.append(buffer, count: n)
+        }
+        stream.close()
+        XCTAssertEqual(readback, bytes)
+        XCTAssertTrue(try storage.verifyChecksum(assetId: assetId))
+
+        // remove (content dedup safe: nessun altro indice punta allo stesso sha)
+        try storage.remove(assetId: assetId)
+        XCTAssertFalse(try storage.exists(assetId: assetId))
+    }
+
+    func testChecksumMismatchDetection() throws {
+        let tmp = try makeTempDir()
+        let storage = try FileAssetStorage(baseDirectory: tmp)
+
+        let bytes = Data([0x01, 0x02, 0x03, 0x04])
+        let wrongMeta = AssetMetadata(length: bytes.count, sha256: "deadbeef", mimeType: "application/octet-stream")
+        let assetId = UUID()
+
+        XCTAssertThrowsError(try storage.save(data: bytes, for: assetId, meta: wrongMeta)) { error in
+            guard case AssetStorageError.checksumMismatch = error else {
+                return XCTFail("Expected checksumMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testDeduplicationBySHA() throws {
+        let tmp = try makeTempDir()
+        let storage = try FileAssetStorage(baseDirectory: tmp)
+
+        let bytes = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let sha = bytes.sha256Hex()
+        let meta = AssetMetadata(length: bytes.count, sha256: sha, mimeType: "application/octet-stream")
+        let id1 = UUID()
+        let id2 = UUID()
+
+        let url1 = try storage.save(data: bytes, for: id1, meta: meta)
+        let url2 = try storage.save(data: bytes, for: id2, meta: meta)
+        XCTAssertEqual(url1.path, url2.path, "Contenuto deve essere deduplicato per SHA")
+
+        // Rimuovi id1 ma lascia id2: il contenuto non deve sparire
+        try storage.remove(assetId: id1)
+        XCTAssertTrue(try storage.exists(assetId: id2))
+        XCTAssertNotNil(try storage.urlIfPresent(assetId: id2))
+    }
+}

--- a/Tests/GraphNextTests/Assets/GRDBFileBackedAssetsTests.swift
+++ b/Tests/GraphNextTests/Assets/GRDBFileBackedAssetsTests.swift
@@ -1,0 +1,82 @@
+//
+//  GRDBFileBackedAssetsTests.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+//
+//  GRDBFileBackedAssetsTests.swift
+//  GraphNextTests
+//
+//  Created by Regia GraphNext on 24/08/2025.
+//
+
+import XCTest
+@testable import GraphNext
+
+final class GRDBFileBackedAssetsTests: XCTestCase {
+
+    private func makeController() throws -> GRDBGraphPersistenceController {
+        // Se hai un helper, usa quello. Qui esempio rapido con path temp:
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_GRDB_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let dbURL = dir.appendingPathComponent("graph.sqlite")
+        let controller = try GRDBGraphPersistenceController(path: dbURL.path, inMemory: false)
+        return controller
+    }
+
+    func testCreateAttachAndRoundTrip() async throws {
+        // AssetStorage default punta ad Application Support; qui lo forziamo a temp per isolare il test
+        let assetsDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
+        try AssetStorageProvider.shared.setStorage(FileAssetStorage(baseDirectory: assetsDir))
+
+        let controller = try makeController()
+
+        // Owner entity
+        let owner = Entity(
+            id: UUID(),
+            type: "doc",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [:]
+        )
+        try await controller.saveEntity(owner)
+
+        // Data fake
+        let data = Data([0x25, 0x50, 0x44, 0x46]) // "%PDF" header-like bytes
+        let asset = try await controller.createAssetAndAttach(
+            data: data,
+            mimeType: "application/pdf",
+            fileName: "sample.pdf",
+            attachTo: owner.id
+        )
+
+        // URL presente?
+        let url = try await controller.assetURLIfPresent(assetId: asset.id)
+        XCTAssertNotNil(url)
+
+        // Load bytes e verifica sha
+        let loaded = try await controller.loadAssetData(assetId: asset.id)
+        XCTAssertEqual(loaded, data)
+
+        // Verify checksum
+        let ok = try AssetStorageProvider.shared.storage.verifyChecksum(assetId: asset.id)
+        XCTAssertTrue(ok)
+
+        // Delete asset file (non entity)
+        try await controller.deleteAsset(assetId: asset.id)
+        let urlAfterDelete = try await controller.assetURLIfPresent(assetId: asset.id)
+        XCTAssertNil(urlAfterDelete)
+    }
+}

--- a/Tests/GraphNextTests/Assets/GRDBGraphPersistenceController+AssetsTests.swift
+++ b/Tests/GraphNextTests/Assets/GRDBGraphPersistenceController+AssetsTests.swift
@@ -22,7 +22,7 @@ final class GRDBGraphPersistenceController_AssetsTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000) // Give GRDB time to migrate
     }
 
-    func testAssetBlobRoundTrip() async throws {
+    func testAssetRoundTrip_FileBacked() async throws {
         let data = Data("hello world".utf8)
         let mimeType = "text/plain"
         let fileName = "test.txt"
@@ -34,15 +34,24 @@ final class GRDBGraphPersistenceController_AssetsTests: XCTestCase {
             attachTo: UUID()
         )
 
-        let (loadedData, metadata) = try await sut.loadAssetBlob(for: asset.id)
+        let loadedData = try await sut.loadAssetData(assetId: asset.id)
 
         XCTAssertEqual(loadedData, data)
-        XCTAssertEqual(metadata.length, data.count)
-        XCTAssertEqual(metadata.mimeType, mimeType)
-        XCTAssertEqual(metadata.fileName, fileName)
+        // Validate metadata via entity payload (file-backed: no direct blob metadata API)
+        let fetchedAsset = try await sut.entity(id: asset.id)
+        XCTAssertNotNil(fetchedAsset)
+        guard let payload = fetchedAsset!.payload else { XCTFail("Missing payload in asset entity"); return }
+        // length
+        if case let .int(len)? = payload["length"] { XCTAssertEqual(len, data.count) } else { XCTFail("Missing length in payload") }
+        // mimeType
+        if case let .string(mt)? = payload["mimeType"] { XCTAssertEqual(mt, mimeType) } else { XCTFail("Missing mimeType in payload") }
+        // fileName
+        if case let .string(fn)? = payload["fileName"] { XCTAssertEqual(fn, fileName) } else { XCTFail("Missing fileName in payload") }
+        // sha256
+        if case let .string(sha)? = payload["sha256"] { XCTAssertEqual(sha, data.sha256Hex()) } else { XCTFail("Missing sha256 in payload") }
     }
 
-    func testCascadeDeleteAssetAlsoDeletesBlob() async throws {
+    func testCascadeDeleteAssetAlsoRemovesFile() async throws {
         let data = Data("to be deleted".utf8)
 
         let asset = try await sut.createAssetAndAttach(
@@ -54,15 +63,13 @@ final class GRDBGraphPersistenceController_AssetsTests: XCTestCase {
 
         try await sut.deleteEntity(id: asset.id)
 
-        // Verifica che la riga nella tabella asset_blobs sia stata eliminata
-        try await sut.dbQueue.read { db in
-            let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM asset_blobs WHERE entityId = ?", arguments: [asset.id.uuidString])
-            XCTAssertEqual(count, 0, "Expected asset blob to be deleted via cascade")
-        }
+        // Verifica che il file locale sia stato rimosso (nessun URL presente)
+        let urlAfterDelete = try AssetStorageProvider.shared.storage.urlIfPresent(assetId: asset.id)
+        XCTAssertNil(urlAfterDelete, "Expected asset file to be removed from local storage")
 
         // E continua a verificare che il caricamento fallisca
         do {
-            _ = try await sut.loadAssetBlob(for: asset.id)
+            _ = try await sut.loadAssetData(assetId: asset.id)
             XCTFail("Expected error when loading deleted asset blob")
         } catch {
             // Expected

--- a/Tests/GraphNextTests/Persistence/GRDBMigrationTests.swift
+++ b/Tests/GraphNextTests/Persistence/GRDBMigrationTests.swift
@@ -20,7 +20,7 @@ final class GRDBMigrationTests: XCTestCase {
         
         try dbQueue.read { db in
             // ✅ Check required tables exist
-            let requiredTables = ["entities", "relationships", "asset_blobs"]
+            let requiredTables = ["entities", "relationships"]
             for table in requiredTables {
                 let count = try Int.fetchOne(
                     db,
@@ -29,6 +29,14 @@ final class GRDBMigrationTests: XCTestCase {
                 )
                 XCTAssertEqual(count, 1, "Missing table: \(table)")
             }
+            
+            // ❌ Ensure legacy table `asset_blobs` has been dropped (PR3)
+            let legacyCount = try Int.fetchOne(
+                db,
+                sql: "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+                arguments: ["asset_blobs"]
+            )
+            XCTAssertEqual(legacyCount, 0, "Legacy table asset_blobs should not exist after migrations")
             
             // ✅ Check required indices exist
             let requiredIndices = ["idx_entities_type", "idx_rel_from", "idx_rel_to"]
@@ -61,14 +69,6 @@ final class GRDBMigrationTests: XCTestCase {
                 XCTAssertTrue(relColumns.contains(col), "Missing column in relationships: \(col)")
             }
 
-            // ✅ Check columns for `asset_blobs`
-            let assetColumns = try db.columns(in: "asset_blobs").map(\.name)
-            let expectedAssetColumns = [
-                "entityId", "data", "length", "sha256", "mimeType", "fileName"
-            ]
-            for col in expectedAssetColumns {
-                XCTAssertTrue(assetColumns.contains(col), "Missing column in asset_blobs: \(col)")
-            }
         }
     }
 }

--- a/Tests/GraphNextTests/Sync/CloudKitAssetThresholdTests.swift
+++ b/Tests/GraphNextTests/Sync/CloudKitAssetThresholdTests.swift
@@ -1,0 +1,90 @@
+//
+//  CloudKitAssetThresholdTests.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 25/08/25.
+//
+
+
+import XCTest
+import CloudKit
+@testable import GraphNext
+
+final class CloudKitAssetThresholdTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_Threshold_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: dir))
+    }
+
+    func testAsCKRecord_SkipsAttachmentWhenOverThreshold() throws {
+        // Soglia 4 byte
+        _CKAttachmentThreshold.bytes = 4
+
+        // 5 byte → sopra soglia
+        let data = Data("12345".utf8)
+        let assetId = UUID()
+        let meta = AssetMetadata(length: data.count,
+                                 sha256: data.sha256Hex(),
+                                 mimeType: "text/plain",
+                                 fileName: "big.txt")
+        _ = try AssetStorageProvider.shared.storage.save(data: data, for: assetId, meta: meta)
+
+        let entity = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string("text/plain"),
+                "fileName": .string("big.txt"),
+                "length": .int(data.count),
+                "sha256": .string(meta.sha256)
+            ]
+        )
+
+        let record = entity.asCKRecord()
+        XCTAssertNil(record["file"] as? CKAsset, "CKAsset should be skipped when size > threshold")
+    }
+
+    func testAsCKRecord_AttachesWhenUnderThreshold() throws {
+        // Soglia 10 byte
+        _CKAttachmentThreshold.bytes = 10
+
+        let data = Data("1234".utf8) // 4 byte < 10
+        let assetId = UUID()
+        let meta = AssetMetadata(length: data.count,
+                                 sha256: data.sha256Hex(),
+                                 mimeType: "text/plain",
+                                 fileName: "small.txt")
+        _ = try AssetStorageProvider.shared.storage.save(data: data, for: assetId, meta: meta)
+
+        let entity = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string("text/plain"),
+                "fileName": .string("small.txt"),
+                "length": .int(data.count),
+                "sha256": .string(meta.sha256)
+            ]
+        )
+
+        let record = entity.asCKRecord()
+        XCTAssertNotNil(record["file"] as? CKAsset, "CKAsset should be attached when size <= threshold")
+    }
+}

--- a/Tests/GraphNextTests/Sync/CloudKitAssetsMapperTests.swift
+++ b/Tests/GraphNextTests/Sync/CloudKitAssetsMapperTests.swift
@@ -1,0 +1,53 @@
+//
+//  CloudKitAssetsMapperTests.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+import XCTest
+import CloudKit
+@testable import GraphNext
+
+final class CloudKitAssetsMapperTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_CKMapper_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: dir))
+    }
+
+    func testAsCKRecord_AttachesCKAssetIfLocalURLExists() throws {
+        let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        let sha = data.sha256Hex()
+        let assetId = UUID()
+        let meta = AssetMetadata(length: data.count, sha256: sha, mimeType: "application/octet-stream", fileName: "deadbeef.bin")
+        _ = try AssetStorageProvider.shared.storage.save(data: data, for: assetId, meta: meta)
+
+        let entity = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string("application/octet-stream"),
+                "fileName": .string("deadbeef.bin"),
+                "length": .int(data.count),
+                "sha256": .string(sha)
+            ]
+        )
+
+        let record = entity.asCKRecord()
+        
+        let ckAsset = record["file"] as? CKAsset
+        XCTAssertNotNil(ckAsset)
+        XCTAssertNotNil(ckAsset?.fileURL)
+    }
+}

--- a/Tests/GraphNextTests/Sync/CloudKitAssetsOnDemandTests.swift
+++ b/Tests/GraphNextTests/Sync/CloudKitAssetsOnDemandTests.swift
@@ -1,0 +1,114 @@
+//
+//  CloudKitAssetsOnDemandTests.swift
+//  GraphNext
+//
+//  Created by Valerio Buriani on 24/08/25.
+//
+
+
+import XCTest
+import Combine
+import CloudKit
+@testable import GraphNext
+
+final class CloudKitAssetsOnDemandTests: XCTestCase {
+
+    var cancellables = Set<AnyCancellable>()
+
+    override func setUpWithError() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("GN_Assets_CKFetch_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        AssetStorageProvider.shared.setStorage(try FileAssetStorage(baseDirectory: dir))
+    }
+
+    override func tearDown() {
+        CloudKitTestHooks.fetchAssetRecord = nil
+        cancellables.removeAll()
+    }
+
+    func testFetchAssetIfNeeded_UsesHookAndSavesToStorage_AndNotifiesStore() async throws {
+        // Prepara un file temporaneo che simula il contenuto di CKAsset
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let tempFile = tempDir.appendingPathComponent("ckasset-\(UUID().uuidString).bin")
+        let payload = Data([0x41, 0x42, 0x43, 0x44]) // "ABCD"
+        try payload.write(to: tempFile)
+
+        let assetId = UUID()
+        CloudKitTestHooks.fetchAssetRecord = { requested in
+            guard requested == assetId else { return nil }
+            let zoneID = CKRecordZone.ID(zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+            let recordID = CKRecord.ID(recordName: requested.uuidString, zoneID: zoneID)
+            let rec = CKRecord(recordType: "Entity", recordID: recordID)
+            rec["file"] = CKAsset(fileURL: tempFile)
+            return rec
+        }
+
+        let store = await GraphStore()
+        let entity = Entity(
+            id: assetId,
+            type: "asset",
+            tag: [],
+            group: [],
+            created: .init(by: "test", at: .now),
+            updated: nil,
+            version: 1,
+            sharedWith: [],
+            permissions: nil,
+            payload: [
+                "mimeType": .string("application/octet-stream"),
+                "fileName": .string("hook.bin"),
+                "length": .int(payload.count),
+                "sha256": .string(payload.sha256Hex())
+            ]
+        )
+        await store.add(node: entity, isRemote: false)
+
+        let exp = expectation(description: "store notified about asset readiness")
+        await store.changeFeed.sink { change in
+            if case let .update(node, isRemote) = change, let e = node as? Entity, e.id == assetId {
+                XCTAssertTrue(isRemote)
+                exp.fulfill()
+            }
+        }.store(in: &cancellables)
+
+        let config = CloudKitSyncConfig()
+        let dummyPersistence = DummyPersistence()
+        let sync = await CloudKitSync(persistence: dummyPersistence, store: store, backend: MockRemoteBackend(), configuration: config)
+
+        try await sync.fetchAssetIfNeededAndNotify(assetId: assetId)
+
+        let url = try AssetStorageProvider.shared.storage.urlIfPresent(assetId: assetId)
+        XCTAssertNotNil(url)
+
+        await fulfillment(of: [exp], timeout: 1.0)
+    }
+}
+
+// MARK: - Dummy Persistence
+
+final class DummyPersistence: GraphPersistenceController {
+
+    func saveEntity(_ entity: Entity) async throws {}
+    func entity(id: UUID) async throws -> Entity? { nil }
+    func deleteEntity(id: UUID) async throws {}
+    func deleteEntityAndAttachedRelationships(id: UUID) async throws {}
+    func saveEntities(_ entities: [Entity]) async throws {}
+    func deleteEntities(_ ids: [UUID]) async throws {}
+    func saveRelationship(_ relationship: Relationship) async throws {}
+    func relationship(id: UUID) async throws -> Relationship? { nil }
+    func deleteRelationship(id: UUID) async throws {}
+    func saveRelationships(_ relationships: [Relationship]) async throws {}
+    func deleteRelationships(_ ids: [UUID]) async throws {}
+    func allEntities() async throws -> [Entity] { [] }
+    func allRelationships() async throws -> [Relationship] { [] }
+    func reset() async throws {}
+
+    func queryEntities(matching type: String?) async throws -> [Entity] {
+        return []
+    }
+
+    func queryRelationships(matching type: String?) async throws -> [Relationship] {
+        return []
+    }
+}

--- a/Tests/GraphNextTests/Sync/Mock/MockRemoteBackend.swift
+++ b/Tests/GraphNextTests/Sync/Mock/MockRemoteBackend.swift
@@ -85,4 +85,8 @@ final class MockRemoteBackend: RemoteSyncBackend {
         deletedRelationshipIDsBuffer.removeAll()
         return ids
     }
+    
+    func subscribeToRemoteChanges() async throws {
+        // no-op in tests
+    }
 }


### PR DESCRIPTION
📌 Contesto
Gli asset non sono più gestiti come BLOB nei database (GRDB/Core Data), ma come file-backed tramite AssetStorage (FileAssetStorage di default).
Questo semplifica lo schema, velocizza la persistenza e migliora l’integrazione con CloudKit (CKAsset) e Core Data.

⸻

✅ Modifiche principali
	•	AssetStorage
	•	Protocollo AssetStorage e implementazione FileAssetStorage.
	•	Quota configurabile (assetCacheQuotaBytes) con eviction LRU.
	•	Aggiornamento lastAccess a ogni accesso.
	•	Config
	•	GraphNextConfig.assetCacheQuotaBytes: quota globale asset cache.
	•	CloudKitSyncConfig.assetThresholdBytes: soglia massima (default 15 MB) per allegare file a CloudKit.
	•	CloudKit
	•	Entity.asCKRecord allega CKAsset solo se il file locale è ≤ soglia.
	•	On-demand fetch invariato (fetchAssetIfNeeded...).
	•	Documentazione
	•	Nuovo Docs/AssetsFileBacked.md con panoramica, API e best practice.
	•	Test
	•	Round-trip file-backed (GRDB/Core Data).
	•	Cascade delete → file rimosso.
	•	Eviction LRU (quota piccola → rimuove meno recente).
	•	CloudKit attachment threshold (sotto/sopra soglia).

⸻

📝 Definition of Done
	•	Nessun BLOB in DB
	•	Tutti i test verdi (Store, Persistence, Sync, Assets, CloudKit)
	•	Documentazione aggiornata
	•	Nessun warning nuovo
	•	Pull-from-zero rapido (asset scaricati solo on-demand)